### PR TITLE
2.2.0-feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy-router",
-  "version": "2.1.2",
+  "version": "2.1.2-rc.1",
   "description": "A router plugin for astroboy.ts.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy-router",
-  "version": "2.1.2-rc.3",
+  "version": "2.1.2-rc.4",
   "description": "A router plugin for astroboy.ts.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy-router",
-  "version": "2.1.2-rc.9",
+  "version": "2.1.2-rc.10",
   "description": "A router plugin for astroboy.ts.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy-router",
-  "version": "2.1.2-rc.1",
+  "version": "2.1.2-rc.2",
   "description": "A router plugin for astroboy.ts.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy-router",
-  "version": "2.1.2-rc.8",
+  "version": "2.1.2-rc.9",
   "description": "A router plugin for astroboy.ts.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy-router",
-  "version": "2.1.2-rc.6",
+  "version": "2.1.2-rc.7",
   "description": "A router plugin for astroboy.ts.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy-router",
-  "version": "2.1.2-rc.7",
+  "version": "2.1.2-rc.8",
   "description": "A router plugin for astroboy.ts.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy-router",
-  "version": "2.1.2-rc.2",
+  "version": "2.1.2-rc.3",
   "description": "A router plugin for astroboy.ts.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy-router",
-  "version": "2.1.2-rc.5",
+  "version": "2.1.2-rc.6",
   "description": "A router plugin for astroboy.ts.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy-router",
-  "version": "2.1.2-rc.4",
+  "version": "2.1.2-rc.5",
   "description": "A router plugin for astroboy.ts.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/decorators/params.factory.ts
+++ b/src/decorators/params.factory.ts
@@ -46,11 +46,12 @@ export function FromBodyFactory(options: Partial<IBodyArgsOptions> = {}) {
 export function FromRequestFactory(): ArgsFactory;
 export function FromRequestFactory(options: Partial<IRequestArgsOptions>): ArgsFactory;
 export function FromRequestFactory(options: Partial<IRequestArgsOptions> = {}) {
-  const { transform, useStatic, useStrict = false, extract, type } = options;
+  const { transform, useStatic, useStrict = false, extract, type, useTypes = [] } = options;
   return function dynamic_args<T>(prototype: T, propertyKey: string, index: number) {
     const routes = tryGetRouter(prototype, "routes");
     const args = tryGetRoute(routes, propertyKey, "args");
     const types = Reflect.getMetadata("design:paramtypes", prototype, propertyKey) || [];
+    const reflectType = types[index];
     if (index > args.maxIndex) args.maxIndex = index;
     args.context[index] = {
       index,
@@ -59,7 +60,7 @@ export function FromRequestFactory(options: Partial<IRequestArgsOptions> = {}) {
       extract,
       static: useStatic,
       strict: !!useStrict,
-      ctor: typeFilter(types[index])
+      ctor: useTypes.length > 0 ? useTypes : [typeFilter(reflectType)]
     };
   };
 }

--- a/src/decorators/params.factory.ts
+++ b/src/decorators/params.factory.ts
@@ -1,4 +1,4 @@
-import { ArgsFactory, IArgsOptions, ARGS, InnerArgsOptions } from "../metadata";
+import { ArgsFactory, ARGS, IRequestArgsOptions, IBodyArgsOptions, IQueryArgsOptions, IParamsArgsOptions } from "../metadata";
 import { tryGetRoute, tryGetRouter } from "./utils";
 
 import "reflect-metadata";
@@ -11,9 +11,9 @@ import "reflect-metadata";
  * @returns {FromParamsFactory}
  */
 export function FromParamsFactory(): ArgsFactory;
-export function FromParamsFactory(options: Partial<IArgsOptions<{ params?: any }>>): ArgsFactory;
-export function FromParamsFactory(options: Partial<IArgsOptions<{ params?: any }>> = {}) {
-  return FromRequestFactory({ ...options, type: ARGS.Params });
+export function FromParamsFactory(options: Partial<IParamsArgsOptions>): ArgsFactory;
+export function FromParamsFactory(options: Partial<IParamsArgsOptions> = {}) {
+  return FromRequestFactory({ type: ARGS.Params, ...options });
 }
 
 /**
@@ -24,9 +24,9 @@ export function FromParamsFactory(options: Partial<IArgsOptions<{ params?: any }
  * @returns {FromQueryFactory}
  */
 export function FromQueryFactory(): ArgsFactory;
-export function FromQueryFactory(options: Partial<IArgsOptions<{ query?: any }>>): ArgsFactory;
-export function FromQueryFactory(options: Partial<IArgsOptions<{ query?: any }>> = {}) {
-  return FromRequestFactory({ ...options, type: ARGS.Query });
+export function FromQueryFactory(options: Partial<IQueryArgsOptions>): ArgsFactory;
+export function FromQueryFactory(options: Partial<IQueryArgsOptions> = {}) {
+  return FromRequestFactory({ type: ARGS.Query, ...options });
 }
 
 /**
@@ -38,15 +38,15 @@ export function FromQueryFactory(options: Partial<IArgsOptions<{ query?: any }>>
  * @returns {FromBodyFactory}
  */
 export function FromBodyFactory(): ArgsFactory;
-export function FromBodyFactory(options: Partial<IArgsOptions<{ body?: any }>>): ArgsFactory;
-export function FromBodyFactory(options: Partial<IArgsOptions<{ body?: any }>> = {}) {
-  return FromRequestFactory({ ...options, useStrict: true, type: ARGS.BodyAppJson });
+export function FromBodyFactory(options: Partial<IBodyArgsOptions>): ArgsFactory;
+export function FromBodyFactory(options: Partial<IBodyArgsOptions> = {}) {
+  return FromRequestFactory({ useStrict: true, type: ARGS.BodyAppJson, ...options });
 }
 
 export function FromRequestFactory(): ArgsFactory;
-export function FromRequestFactory(options: Partial<InnerArgsOptions>): ArgsFactory;
-export function FromRequestFactory(options: Partial<InnerArgsOptions> = {}) {
-  const { transform, useStatic = false, useStrict = false, type } = options;
+export function FromRequestFactory(options: Partial<IRequestArgsOptions>): ArgsFactory;
+export function FromRequestFactory(options: Partial<IRequestArgsOptions> = {}) {
+  const { transform, useStatic, useStrict = false, extract, type } = options;
   return function dynamic_args<T>(prototype: T, propertyKey: string, index: number) {
     const routes = tryGetRouter(prototype, "routes");
     const args = tryGetRoute(routes, propertyKey, "args");
@@ -54,9 +54,10 @@ export function FromRequestFactory(options: Partial<InnerArgsOptions> = {}) {
     if (index > args.maxIndex) args.maxIndex = index;
     args.context[index] = {
       index,
-      type: type || ARGS.All,
-      resolver: transform,
-      static: !!useStatic,
+      type: type || ARGS.Custom,
+      transform,
+      extract,
+      static: useStatic,
       strict: !!useStrict,
       ctor: typeFilter(types[index])
     };

--- a/src/decorators/route.factory.ts
+++ b/src/decorators/route.factory.ts
@@ -2,20 +2,29 @@ import { METHOD, IRouteFactory, IRouterDefine, IRoutePathConfig, IPipeProcess, P
 import { tryGetRouter, tryGetRoute } from "./utils";
 
 export interface CustomRouteOptions {
+  /** 路由方法，默认值：`'GET'` */
   method?: METHOD;
+  /** url模板，用来自定义生成的url，默认值：`[]` */
   tpls?: (string | { tpl: string; sections?: { [key: string]: string } })[];
+  /** 路由名字，默认值：`undefined` */
   name?: string;
+  /** 扩展结构，默认：`{}` */
   extensions?: any;
 }
 
-export interface CustomPipeOptions extends Partial<IPipeBaseCOnfig> {
+export interface CustomPipeOptions extends Partial<IPipeBaseConfig> {
+  /** 扩展结构，默认：`{}` */
   extensions?: any;
 }
 
-interface IPipeBaseCOnfig {
+interface IPipeBaseConfig {
+  /** 是否重载覆盖Router级别的pipe配置，默认：`false` */
   override: boolean;
+  /** 附加pipe的方式，默认：`'push'` */
   zIndex: "unshift" | "push";
+  /** 附加的pipes，默认：`[]` */
   rules: IPipeProcess[];
+  /** pipes的错误处理捕捉函数，默认：`undefined` */
   handler: PipeErrorHandler;
 }
 
@@ -23,7 +32,7 @@ interface RouteBaseConfig {
   name?: string;
   method?: METHOD;
   path?: IRoutePathConfig[];
-  pipeConfigs?: Partial<IPipeBaseCOnfig>;
+  pipeConfigs?: Partial<IPipeBaseConfig>;
   extensions?: MapLike<any>;
 }
 
@@ -72,14 +81,15 @@ function RouteFactory(options: RouteBaseConfig): IRouteFactory {
  * @exports
  */
 export function CustomRouteFactory(options: CustomRouteOptions): IRouteFactory {
-  const { method, name, tpls = [] } = options;
+  const { method, name, tpls = [], extensions = {} } = options;
   return function customRoute(target: IRouterDefine, propertyKey: string, descriptor?: PropertyDescriptor) {
     RouteFactory({
       name,
       method,
       path: tpls.map(item =>
         typeof item === "string" ? { path: undefined, sections: {}, urlTpl: item } : { path: undefined, sections: item.sections || {}, urlTpl: item.tpl }
-      )
+      ),
+      extensions
     })(target, propertyKey, descriptor);
   };
 }

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -144,7 +144,7 @@ export function createArgSolution(route: IRoute<any>): void {
     }
     const { type, ctor: classType, extract, transform = defaultTransform, static: useStatic, strict: useStrict = false } = context[step];
     const staticX = typeTransform({ useStatic, type: classType, useStrict });
-    const solution = { static: staticX, transform };
+    const solution = { static: staticX, transform, type: classType };
     switch (type) {
       case ARGS.Custom:
         solutions.push({ ...solution, extract: extract || useAll });

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -180,11 +180,9 @@ function typeTransform(context: ITypeTransformContext): ArgsResolveStatic | unde
   switch (type) {
     case String:
     case Number:
-      return d => type(d);
+      return d => useStatic(type(d));
     case Boolean:
-      return useStrict ? d => d === true : d => String(d) === "true";
-    case undefined:
-      return undefined;
+      return useStrict ? d => useStatic(d === true) : d => useStatic(String(d) === "true");
     // 暂时不支持其他复杂类型的类型转换处理，除非手动提供
     // TODO 支持静态类型转换
     default:

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -99,7 +99,8 @@ export function tryGetRoute(routes: any, key: string, subKey?: string) {
 export function readPath({ group, pattern }: IRouter<any>, route: IRoute) {
   const { patterns = [], sections: routerSections = {} } = pattern;
   const { pathConfig: configs = [], pathOverride: override = false } = route;
-  route.path = (<(IRoutePathConfig | IRouteUrlPattern)[]>(!override ? configs : patterns)).map(config => {
+  const useRouterPatterns = !override && patterns.length > 0;
+  route.path = (<(IRoutePathConfig | IRouteUrlPattern)[]>(!useRouterPatterns ? configs : patterns)).map(config => {
     const { pattern: tpl, sections: data = {} } = config;
     const isPlainUrl = tpl === undefined;
     if (isPlainUrl) return (<IRoutePathConfig>config).path || "";

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -180,9 +180,9 @@ function typeTransform(context: ITypeTransformContext): ArgsResolveStatic | unde
   switch (type) {
     case String:
     case Number:
-      return d => useStatic(type(d));
+      return (data, opts) => useStatic(type(data), opts);
     case Boolean:
-      return useStrict ? d => useStatic(d === true) : d => useStatic(String(d) === "true");
+      return useStrict ? (data, opts) => useStatic(data === true, opts) : (data, opts) => useStatic(String(data) === "true", opts);
     // 暂时不支持其他复杂类型的类型转换处理，除非手动提供
     // TODO 支持静态类型转换
     default:

--- a/src/entrance/build.ts
+++ b/src/entrance/build.ts
@@ -65,8 +65,8 @@ export function createBuildHelper({ route }: IRouteBuildContext<any>) {
         params: this.ctx.params || {},
         body: this.ctx.request.body || {}
       };
-      return args.solutions.map(({ extract: fetch, transform, static: typeResolve }) => {
-        return !typeResolve ? transform(fetch(context)) : typeResolve(transform(fetch(context)), options);
+      return args.solutions.map(({ extract: fetch, transform, static: typeResolve, type }) => {
+        return !typeResolve ? transform(fetch(context)) : typeResolve(transform(fetch(context)), { ...options, type });
       });
     }
   };

--- a/src/entrance/build.ts
+++ b/src/entrance/build.ts
@@ -35,7 +35,7 @@ export function defaultOnBuild(context: IRouteBuildContext, descriptor: IRouteDe
   const needOnEnter = (lifeCycle.onEnter || []).length > 0;
   const needOnQuit = (lifeCycle.onQuit || []).length > 0;
   const sourceRouteMethod: (...args: any[]) => Promise<any> = descriptor.value;
-  const hooks = createLifeHooks(lifeCycle);
+  const hooks = createLifeHooks(context);
   const helpers = createBuildHelper(context);
   descriptor.value = async function() {
     if (needOnPipe) await hooks.runOnPipes.call(this);
@@ -93,9 +93,10 @@ function defaultFetchArgs(delegator: any): IArgSolutionsContext {
  *
  * @author Big Mogician
  * @export
- * @param {Partial<IRouterLifeCycle>} lifeCycle
+ * @param {IRouteBuildContext} context
  */
-export function createLifeHooks(lifeCycle: Partial<IRouterLifeCycle>) {
+export function createLifeHooks(context: IRouteBuildContext<any>) {
+  const { lifeCycle } = context.router;
   return {
     /**
      * 执行OnPipes生命周期
@@ -106,7 +107,7 @@ export function createLifeHooks(lifeCycle: Partial<IRouterLifeCycle>) {
      */
     async runOnPipes(this: any) {
       for (const eachOnPipe of lifeCycle.onPipes || []) {
-        await eachOnPipe(this);
+        await eachOnPipe(context, this);
       }
     },
     /**
@@ -118,7 +119,7 @@ export function createLifeHooks(lifeCycle: Partial<IRouterLifeCycle>) {
      */
     async runOnEnters(this: any) {
       for (const eachOnEnter of lifeCycle.onEnter || []) {
-        await eachOnEnter(this);
+        await eachOnEnter(context, this);
       }
     },
     /**
@@ -130,7 +131,7 @@ export function createLifeHooks(lifeCycle: Partial<IRouterLifeCycle>) {
      */
     async runOnQuits(this: any) {
       for (const eachOnQuit of lifeCycle.onQuit || []) {
-        await eachOnQuit(this);
+        await eachOnQuit(context, this);
       }
     },
     /**

--- a/src/entrance/build.ts
+++ b/src/entrance/build.ts
@@ -55,20 +55,18 @@ export function createBuildHelper({ route }: IRouteBuildContext<any>) {
      * 解析注入参数
      *
      * @author Big Mogician
-     * @param {*} this
-     * @param {(caller: any) => IArgSolutionsContext} [contextResolve]
+     * @param {any} this
+     * @param {any} [options={}]
      */
-    parseArgs(this: any, contextResolve?: (caller: any) => IArgSolutionsContext) {
+    parseArgs(this: any, options: any = {}) {
       if (!args.hasArgs) return [];
-      const context: IArgSolutionsContext = !contextResolve
-        ? {
-            query: this.ctx.query || {},
-            params: this.ctx.params || {},
-            body: this.ctx.request.body || {}
-          }
-        : contextResolve(this);
-      return args.solutions.map(([fetch, transform]) => {
-        return transform(fetch(context));
+      const context: IArgSolutionsContext = {
+        query: this.ctx.query || {},
+        params: this.ctx.params || {},
+        body: this.ctx.request.body || {}
+      };
+      return args.solutions.map(({ extract: fetch, transform, static: typeResolve }) => {
+        return !typeResolve ? transform(fetch(context)) : typeResolve(transform(fetch(context)), options);
       });
     }
   };

--- a/src/entrance/build.ts
+++ b/src/entrance/build.ts
@@ -1,4 +1,4 @@
-import { IRoute, IRouter, IRouteBuildContext, IPipeResolveContext, IRouterLifeCycle, IArgsSolutionsContext, IRouteDescriptor } from "../metadata";
+import { IRoute, IRouter, IRouteBuildContext, IPipeResolveContext, IRouterLifeCycle, IArgSolutionsContext, IRouteDescriptor } from "../metadata";
 
 export function buildRouteMethod(prototype: any, methodName: string, router: IRouter, route: IRoute) {
   const { lifeCycle = {} } = router;
@@ -56,11 +56,11 @@ export function createBuildHelper({ route }: IRouteBuildContext<any>) {
      *
      * @author Big Mogician
      * @param {*} this
-     * @param {(caller: any) => IArgsSolutionsContext} [contextResolve]
+     * @param {(caller: any) => IArgSolutionsContext} [contextResolve]
      */
-    parseArgs(this: any, contextResolve?: (caller: any) => IArgsSolutionsContext) {
+    parseArgs(this: any, contextResolve?: (caller: any) => IArgSolutionsContext) {
       if (!args.hasArgs) return [];
-      const context: IArgsSolutionsContext = !contextResolve
+      const context: IArgSolutionsContext = !contextResolve
         ? {
             query: this.ctx.query || {},
             params: this.ctx.params || {},

--- a/src/entrance/build.ts
+++ b/src/entrance/build.ts
@@ -1,4 +1,13 @@
-import { IRoute, IRouter, IRouteBuildContext, IPipeResolveContext, IRouterLifeCycle, IArgSolutionsContext, IRouteDescriptor } from "../metadata";
+import {
+  IRoute,
+  IRouter,
+  IRouteBuildContext,
+  IPipeResolveContext,
+  IRouterLifeCycle,
+  IArgSolutionsContext,
+  IRouteDescriptor,
+  IParseArgsOptions
+} from "../metadata";
 
 export function buildRouteMethod(prototype: any, methodName: string, router: IRouter, route: IRoute) {
   const { lifeCycle = {} } = router;
@@ -55,20 +64,25 @@ export function createBuildHelper({ route }: IRouteBuildContext<any>) {
      * 解析注入参数
      *
      * @author Big Mogician
-     * @param {any} this
-     * @param {any} [options={}]
+     * @param {any} this delegator
+     * @param {Partial<IParseArgsOptions>} [options={}]
      */
-    parseArgs(this: any, options: any = {}) {
+    parseArgs(this: any, options: Partial<IParseArgsOptions> = {}) {
+      const { fetchArgs = defaultFetchArgs } = options;
       if (!args.hasArgs) return [];
-      const context: IArgSolutionsContext = {
-        query: this.ctx.query || {},
-        params: this.ctx.params || {},
-        body: this.ctx.request.body || {}
-      };
+      const context = fetchArgs(this);
       return args.solutions.map(({ extract: fetch, transform, static: typeResolve, type }) => {
         return !typeResolve ? transform(fetch(context)) : typeResolve(transform(fetch(context)), { ...options, type });
       });
     }
+  };
+}
+
+function defaultFetchArgs(delegator: any): IArgSolutionsContext {
+  return {
+    query: delegator.ctx.query || {},
+    params: delegator.ctx.params || {},
+    body: delegator.ctx.request.body || {}
   };
 }
 

--- a/src/entrance/build.ts
+++ b/src/entrance/build.ts
@@ -71,7 +71,7 @@ export function createBuildHelper({ route }: IRouteBuildContext<any>) {
       const { fetchArgs = defaultFetchArgs } = options;
       if (!args.hasArgs) return [];
       const context = fetchArgs(this);
-      return args.solutions.map(({ extract: fetch, transform, static: typeResolve, type }) => {
+      return args.solutions.map(({ extract: fetch, transform, static: typeResolve, type = [] }) => {
         return !typeResolve ? transform(fetch(context)) : typeResolve(transform(fetch(context)), { ...options, type });
       });
     }

--- a/src/metadata/base.ts
+++ b/src/metadata/base.ts
@@ -24,12 +24,6 @@ export interface IAstroboyBaseClass<T = any> {
   ctx: T;
 }
 
-export interface IRoutePathConfig {
-  path: string | undefined;
-  urlTpl: string | undefined;
-  sections: MapLike<string>;
-}
-
 export interface IRoutePipeDefine {
   handler: PipeErrorHandler;
 }
@@ -38,32 +32,112 @@ export interface IRouterPipeDefine extends IRoutePipeDefine {
   extend?: boolean;
 }
 
+// tslint:disable-next-line: class-name
+export interface IRouteUrlTpl_DEPERACTED {
+  tpl: string;
+  sections?: MapLike<string>;
+}
+
+export interface IRouteUrlPattern {
+  pattern: string;
+  sections?: MapLike<string>;
+}
+
+export interface IRoutePathConfig {
+  path?: string;
+  pattern: string | undefined;
+  sections: MapLike<string>;
+}
+
+export interface IRouterPatternConfig {
+  patterns: IRouteUrlPattern[];
+  sections: MapLike<any>;
+}
+
+/**
+ * ## Astroboy-Router 路由定义
+ *
+ * @author Big Mogician
+ * @export
+ * @interface IRoute
+ * @template P pipe resturn type
+ */
 export interface IRoute<P = void> {
+  /** 当前路由是否已经被解析完毕，默认：`false` */
   resolved: boolean;
+  /** 当前路由名称，用于路由表生成的备注，默认：`undefined` */
   name: Unsure<string>;
+  /** 当前路由的http协议类型，默认：`['GET']` */
   method: METHOD[];
+  /** 当前路由解析后的所有url集合，默认：`[]` */
   path: Array<string>;
+  /** 当前路由所有url-pattern集合，默认：`[]` */
   pathConfig: Array<IRoutePathConfig>;
+  /** 当前路由url-pattern集合是否覆盖父路由集的规则，默认：`false` */
+  pathOverride: boolean;
+  /** 当前路由所有的pipe管道集合，默认：`{ extend: true, rules: [] }` */
   pipes: IPipeResolveContext<P> & { extend: boolean };
+  /** 当前路由的所有args参数定义，默认：`{ hasArgs: false, context: {}, maxIndex: -1, aolutions: [] }` */
   args: IRouteArguContent;
+  /** 扩展字段集，用于第三方进行扩展内容补充，默认：`{}` */
   extensions: MapLike<any>;
 }
 
+/**
+ * ## Astroboy-Router 路由集定义
+ *
+ * @author Big Mogician
+ * @export
+ * @interface IRouter
+ * @template P pipe return type
+ */
 export interface IRouter<P = void> {
+  /** 路由集标识，group代表着url中的表示业务范畴的一级，默认：`undefined` */
   group: string;
+  /** 路由组，由所有路由方法组成的map-like对象，默认：`{}` */
   routes: MapLike<IRoute>;
+  /** 路由集的模式，为当前路由集定制生成url的规则，可以被路由的模式覆盖，默认：`{ patterns: [], sections: {} }` */
+  pattern: IRouterPatternConfig;
+  /** 依赖的服务列表，兼容v1版本存在，默认：`new Map()` */
   dependency: Map<Constructor<any>, string>;
+  /** 路由集的管道中间件，定义所有子路由的默认前置流程，默认：`{ rules: [] }` */
   pipes: IPipeResolveContext<P>;
+  /** 路由集的Create构造钩子，用于覆盖或扩展控制器路由初始化的后续逻辑，默认：`[]` */
   onCreate: Array<IRouterCreateDefine>;
+  /** 路由集的路由生命周期钩子，用于定义自路由所有生命周期行为，默认：`[]` */
   lifeCycle: Partial<IRouterLifeCycle>;
+  /** 扩展字段集，用于第三方进行扩展内容补充，默认：`{}` */
   extensions: MapLike<any>;
 }
 
 export interface IRouterMetaConfig<P = void> {
   group?: string;
   pipes?: IPipeResolveContext<P>;
+  pattern?: Partial<{
+    patterns: (string | IRouteUrlPattern)[];
+    sections: MapLike<string>;
+  }>;
   extensions?: MapLike<any>;
-  register?(process: IRouterEvents): void;
+  /**
+   * ### 注册路由钩子
+   * * example 👇:
+   * ```typescript
+   * @Router({
+   *   group: "xxx",
+   *   register(delegate) {
+   *     delegate.lifecycle("onEnter", ({ name }, controller) => {
+   *       console.log(`route ${name} is running.`);
+   *     })
+   *   }
+   * })
+   * class X { ... }
+   * ```
+   *
+   * @author Big Mogician
+   * @param {IRouterEvents} delegate 挂钩对象的委托
+   * @memberof IRouterMetaConfig
+   */
+  register?(delegate: IRouterEvents): void;
 }
 
 export interface IRouterDefine {

--- a/src/metadata/base.ts
+++ b/src/metadata/base.ts
@@ -27,7 +27,7 @@ export interface IAstroboyBaseClass<T = any> {
 export interface IRoutePathConfig {
   path: string | undefined;
   urlTpl: string | undefined;
-  sections: { [key: string]: string };
+  sections: MapLike<string>;
 }
 
 export interface IRoutePipeDefine {

--- a/src/metadata/lifecycle.ts
+++ b/src/metadata/lifecycle.ts
@@ -1,7 +1,7 @@
 import { IAstroboyBaseClass, IRouter, IRoute } from "./base";
 
-export interface IRouteLifeCycleMethod {
-  <T = any>(ctor: IAstroboyBaseClass<T>): void | Promise<void>;
+export interface IRouteLifeCycleMethod<T = IRouteBuildContext<void>> {
+  (context: T, instance: IAstroboyBaseClass<T>): void | Promise<void>;
 }
 
 export interface IRouterBuildContext<P = void> {

--- a/src/metadata/params.ts
+++ b/src/metadata/params.ts
@@ -1,3 +1,5 @@
+import { MapLike } from "./base";
+
 export enum ARGS {
   All = "@all",
   Custom = "@custom",
@@ -27,9 +29,9 @@ export type ArgsResolveStatic<T = any, OPTIONS = {}> = (data: any, options?: { t
  * @interface IArgsSolutionsContext
  */
 export interface IArgSolutionsContext {
-  body: any;
-  params: any;
-  query: any;
+  body: MapLike<any>;
+  params: MapLike<any>;
+  query: MapLike<any>;
 }
 
 /**
@@ -101,7 +103,11 @@ export interface IRouteArgument {
   ctor?: any;
 }
 
-export interface IArgSolutionPack<SOURCE = any, TYPE = any, OPTIONS = any> {
+export interface IBaseStaticResolveOptions<T> extends Partial<IParseArgsOptions> {
+  type: T;
+}
+
+export interface IArgSolutionPack<SOURCE = any, TYPE = any, OPTIONS extends IBaseStaticResolveOptions<TYPE> = any> {
   extract: ArgsExtraction;
   transform: ArgsTransform<SOURCE, TYPE>;
   static?: ArgsResolveStatic<TYPE, OPTIONS>;
@@ -119,4 +125,9 @@ export interface IRouteArguContent {
   maxIndex: number;
   /** args解决方案，默认：`[]` */
   solutions: Array<IArgSolutionPack>;
+}
+
+export interface IParseArgsOptions {
+  fetchArgs(delegator: any): IArgSolutionsContext;
+  [prop: string]: any;
 }

--- a/src/metadata/params.ts
+++ b/src/metadata/params.ts
@@ -1,5 +1,6 @@
 export enum ARGS {
   All = "@all",
+  Custom = "@custom",
   Params = "params",
   Query = "query",
   BodyAppJson = "body::application/json",
@@ -7,57 +8,104 @@ export enum ARGS {
   BodyFormData = "body::multipart/form-data"
 }
 
-/** 处理解析 */
-export type ArgsResolver<T = any, R = any> = (source: T) => R;
+/** Args转换解析，决定如何处理当前args */
+export type ArgsTransform<T = any, R = any> = (source: T) => R;
 
 export type ArgsFactory<T = any> = (target: T, propertyKey: string, index: number) => void;
 
-export type ArgsDecision = (context: IArgsSolutionsContext) => any;
+/** Args提取函数，决定提取哪一部分的args */
+export type ArgsExtraction = (context: IArgSolutionsContext) => any;
 
-export interface IArgsSolutionsContext {
-  body?: any;
-  params?: any;
-  query?: any;
+/**
+ * ## Args上下文
+ *
+ * @author Big Mogician
+ * @export
+ * @interface IArgsSolutionsContext
+ */
+export interface IArgSolutionsContext {
+  body: any;
+  params: any;
+  query: any;
 }
 
+/**
+ * ## Args装饰器配置
+ *
+ * @author Big Mogician
+ * @export
+ * @interface IArgsOptions
+ * @template TRANS
+ * @template RESULT
+ */
 export interface IArgsOptions<TRANS = any, RESULT = any> {
-  transform: ArgsResolver<TRANS, RESULT>;
-  useStatic: boolean;
-  useStrict: boolean;
+  /** 自定义args转换，默认：`undefined` */
+  transform: ArgsTransform<TRANS, RESULT>;
+  /** 使用静态类型处理函数，默认：`undefined` */
+  useStatic: (data: any) => any;
 }
 
-export interface IAllArgsOptions extends IArgsOptions<IArgsSolutionsContext, any> {
+/**
+ * ## Request-Args装饰器配置
+ *
+ * @author Big Mogician
+ * @export
+ * @interface IRequestArgsOptions
+ * @extends {IArgsOptions<IArgSolutionsContext>}
+ */
+export interface IRequestArgsOptions extends IArgsOptions<IArgSolutionsContext> {
+  /** 自定义args提取，默认：`undefined` */
+  extract: ArgsExtraction;
+  /** 使用严格数值模式，默认：`false` */
+  useStrict: boolean;
+  /** args类型，默认：`ARGS.Custom` */
+  type: ARGS;
+}
+
+export interface IAllArgsOptions extends IArgsOptions<IArgSolutionsContext, any> {
   type: ARGS.All;
 }
 
-export interface IQueryArgsOptions extends IArgsOptions<{ query?: any }, any> {
+export interface IQueryArgsOptions extends IArgsOptions<{ query: any }, any> {
   type: ARGS.Query;
 }
 
-export interface IParamsArgsOptions extends IArgsOptions<{ params?: any }, any> {
+export interface IParamsArgsOptions extends IArgsOptions<{ params: any }, any> {
   type: ARGS.Params;
 }
 
-export interface IBodyArgsOptions extends IArgsOptions<{ body?: any }, any> {
+export interface IBodyArgsOptions extends IArgsOptions<{ body: any }, any> {
   type: ARGS.BodyAppJson | ARGS.BodyFormData | ARGS.BodyUrlEncoded;
 }
 
 export type InnerArgsOptions = IAllArgsOptions | IQueryArgsOptions | IParamsArgsOptions | IBodyArgsOptions;
 
 export interface IRouteArgument {
+  /** args类型，默认：`ARGS.ALL` */
   type: ARGS;
+  /** args在函数的索引，默认：`-1` */
   index: number;
-  resolver?: ArgsResolver;
-  static?: boolean;
+  /** args的提取函数，默认：`context => context` */
+  extract?: ArgsExtraction;
+  /** args的转换函数，默认：`data => data` */
+  transform?: ArgsTransform;
+  /** args的严格模式，兼容url-encoded的类型模糊问题，默认：`false` */
   strict?: boolean;
+  /** args的类型，默认：`undefined` */
   ctor?: any;
+  /** args的静态类型处理函数，默认：`data => data` */
+  static?: (data: any) => any;
 }
 
 export interface IRouteArguContent {
+  /** 是否进行参数解析：默认：`false` */
   hasArgs: boolean;
+  /** 参数上下文集合，默认：`{}` */
   context: {
     [index: number]: IRouteArgument;
   };
+  /** 最大参数索引，默认：`-1` */
   maxIndex: number;
-  solutions: Array<[ArgsDecision, ArgsResolver]>;
+  /** args解决方案，默认：`[]` */
+  solutions: Array<[ArgsExtraction, ArgsTransform]>;
 }

--- a/src/metadata/params.ts
+++ b/src/metadata/params.ts
@@ -8,13 +8,16 @@ export enum ARGS {
   BodyFormData = "body::multipart/form-data"
 }
 
-/** Args转换解析，决定如何处理当前args */
-export type ArgsTransform<T = any, R = any> = (source: T) => R;
-
 export type ArgsFactory<T = any> = (target: T, propertyKey: string, index: number) => void;
 
 /** Args提取函数，决定提取哪一部分的args */
 export type ArgsExtraction = (context: IArgSolutionsContext) => any;
+
+/** Args转换解析，决定如何处理当前args */
+export type ArgsTransform<T = any, R = any> = (source: T) => R;
+
+/** Args静态类型转换，决定如何处理静态类型对象反序列化 */
+export type ArgsResolveStatic<T = any> = (data: any, options?: T) => any;
 
 /**
  * ## Args上下文
@@ -89,12 +92,12 @@ export interface IRouteArgument {
   extract?: ArgsExtraction;
   /** args的转换函数，默认：`data => data` */
   transform?: ArgsTransform;
+  /** args的静态类型处理函数，默认：`data => data` */
+  static?: ArgsResolveStatic;
   /** args的严格模式，兼容url-encoded的类型模糊问题，默认：`false` */
   strict?: boolean;
   /** args的类型，默认：`undefined` */
   ctor?: any;
-  /** args的静态类型处理函数，默认：`data => data` */
-  static?: (data: any) => any;
 }
 
 export interface IRouteArguContent {
@@ -107,5 +110,9 @@ export interface IRouteArguContent {
   /** 最大参数索引，默认：`-1` */
   maxIndex: number;
   /** args解决方案，默认：`[]` */
-  solutions: Array<[ArgsExtraction, ArgsTransform]>;
+  solutions: Array<{
+    extract: ArgsExtraction;
+    transform: ArgsTransform;
+    static?: ArgsResolveStatic;
+  }>;
 }

--- a/src/metadata/params.ts
+++ b/src/metadata/params.ts
@@ -17,7 +17,7 @@ export type ArgsExtraction = (context: IArgSolutionsContext) => any;
 export type ArgsTransform<T = any, R = any> = (source: T) => R;
 
 /** Args静态类型转换，决定如何处理静态类型对象反序列化 */
-export type ArgsResolveStatic<T = any> = (data: any, options?: T) => any;
+export type ArgsResolveStatic<T = any, OPTIONS = {}> = (data: any, options?: { type: T } & OPTIONS) => any;
 
 /**
  * ## Args上下文
@@ -100,6 +100,13 @@ export interface IRouteArgument {
   ctor?: any;
 }
 
+export interface IArgSolutionPack<SOURCE = any, TYPE = any, OPTIONS = any> {
+  extract: ArgsExtraction;
+  transform: ArgsTransform<SOURCE, TYPE>;
+  static?: ArgsResolveStatic<TYPE, OPTIONS>;
+  type?: TYPE;
+}
+
 export interface IRouteArguContent {
   /** 是否进行参数解析：默认：`false` */
   hasArgs: boolean;
@@ -110,9 +117,5 @@ export interface IRouteArguContent {
   /** 最大参数索引，默认：`-1` */
   maxIndex: number;
   /** args解决方案，默认：`[]` */
-  solutions: Array<{
-    extract: ArgsExtraction;
-    transform: ArgsTransform;
-    static?: ArgsResolveStatic;
-  }>;
+  solutions: Array<IArgSolutionPack>;
 }

--- a/src/metadata/params.ts
+++ b/src/metadata/params.ts
@@ -40,12 +40,13 @@ export interface IArgSolutionsContext {
  * @interface IArgsOptions
  * @template TRANS
  * @template RESULT
+ * @template SOPTIONS
  */
-export interface IArgsOptions<TRANS = any, RESULT = any> {
+export interface IArgsOptions<TRANS = any, RESULT = any, SOPTIONS = {}> {
   /** 自定义args转换，默认：`undefined` */
   transform: ArgsTransform<TRANS, RESULT>;
   /** 使用静态类型处理函数，默认：`undefined` */
-  useStatic: (data: any) => any;
+  useStatic: ArgsResolveStatic<RESULT, SOPTIONS>;
 }
 
 /**

--- a/src/metadata/params.ts
+++ b/src/metadata/params.ts
@@ -1,4 +1,4 @@
-import { MapLike } from "./base";
+import { MapLike, Constructor } from "./base";
 
 export enum ARGS {
   All = "@all",
@@ -49,6 +49,8 @@ export interface IArgsOptions<TRANS = any, RESULT = any, SOPTIONS = {}> {
   transform: ArgsTransform<TRANS, RESULT>;
   /** 使用静态类型处理函数，默认：`undefined` */
   useStatic: ArgsResolveStatic<RESULT, SOPTIONS>;
+  /** 使用指定的类型覆盖类型声明 ， 默认：`undefined` */
+  useTypes: Array<Constructor<any>>;
 }
 
 /**
@@ -100,18 +102,18 @@ export interface IRouteArgument {
   /** args的严格模式，兼容url-encoded的类型模糊问题，默认：`false` */
   strict?: boolean;
   /** args的类型，默认：`undefined` */
-  ctor?: any;
+  ctor?: Array<Constructor<any>>;
 }
 
-export interface IBaseStaticResolveOptions<T> extends Partial<IParseArgsOptions> {
-  type: T;
+export interface IBaseStaticResolveOptions<T = any> extends Partial<IParseArgsOptions> {
+  type: T[];
 }
 
 export interface IArgSolutionPack<SOURCE = any, TYPE = any, OPTIONS extends IBaseStaticResolveOptions<TYPE> = any> {
   extract: ArgsExtraction;
   transform: ArgsTransform<SOURCE, TYPE>;
   static?: ArgsResolveStatic<TYPE, OPTIONS>;
-  type?: TYPE;
+  type?: TYPE[];
 }
 
 export interface IRouteArguContent {


### PR DESCRIPTION
* 增强FromRequest装饰器，支持定义static和extract，支持finally钩子
* 增强FromRequest的静态能力扩展
* 增强Router定义Controller全局路由pattern
* 支持CustomRoute覆盖Router的全局pattern
* [breaking changes] createLifeHooks的参数拓宽到context
* [breaking changes] clifeCycle函数的参数拓宽到两个，增加访问context的能力